### PR TITLE
Modify the assessment workflow to use the latest format of the api response

### DIFF
--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -4,7 +4,9 @@
   "specVersion": "0.8",
   "name": "Assessment Workflow",
   "description": "Simple workflow to simulate assessment",
-  "annotations": ["workflow-type/assessment"],
+  "annotations": [
+    "workflow-type/assessment"
+  ],
   "dataInputSchema": "schemas/assessment__main-schema.json",
   "start": "Inject options",
   "states": [
@@ -12,11 +14,30 @@
       "name": "Inject options",
       "type": "inject",
       "data": {
-        "workflowOptions": [
-          { "id": "yamlgreet", "name": "Greeting workflow" },
-          { "id": "wait-or-error", "name": "Wait or Error" },
-          { "id": "hello_world", "name": "Hello World Workflow" }
-        ]
+        "workflowOptions": {
+          "newOptions": [
+            {
+              "id": "yamlgreet",
+              "name": "Greeting workflow"
+            },
+            {
+              "id": "wait-or-error",
+              "name": "Wait or Error"
+            },
+            {
+              "id": "hello_world",
+              "name": "Hello World Workflow"
+            }
+          ],
+          "otherOptions": [],
+          "currentVersion": {
+            "id": "yamlgreet",
+            "name": "Dummy infra workflow option"
+          },
+          "upgradeOptions": [],
+          "migrationOptions": [],
+          "continuationOptions": []
+        }
       },
       "end": true
     }

--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -32,7 +32,7 @@
           "otherOptions": [],
           "currentVersion": {
             "id": "yamlgreet",
-            "name": "Greeting workflow"
+            "name": "Yamlgreet"
           },
           "upgradeOptions": [],
           "migrationOptions": [],

--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -32,7 +32,7 @@
           "otherOptions": [],
           "currentVersion": {
             "id": "yamlgreet",
-            "name": "Recommanded workflow"
+            "name": "Greeting workflow"
           },
           "upgradeOptions": [],
           "migrationOptions": [],

--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -17,10 +17,6 @@
         "workflowOptions": {
           "newOptions": [
             {
-              "id": "yamlgreet",
-              "name": "Greeting workflow"
-            },
-            {
               "id": "wait-or-error",
               "name": "Wait or Error"
             },

--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -28,7 +28,7 @@
           "otherOptions": [],
           "currentVersion": {
             "id": "yamlgreet",
-            "name": "Yamlgreet"
+            "name": "Greeting workflow"
           },
           "upgradeOptions": [],
           "migrationOptions": [],

--- a/workflows/assessment.sw.json
+++ b/workflows/assessment.sw.json
@@ -32,7 +32,7 @@
           "otherOptions": [],
           "currentVersion": {
             "id": "yamlgreet",
-            "name": "Dummy infra workflow option"
+            "name": "Recommanded workflow"
           },
           "upgradeOptions": [],
           "migrationOptions": [],


### PR DESCRIPTION
The workflowOptions object should be like this [https://github.com/parodos-dev/serverless-workflow-examples/tree/main/assessment/assessment-with-jq-expression](https://github.com/parodos-dev/serverless-workflow-examples/tree/main/assessment/assessment-with-jq-expression)