### PR TITLE
Add Requested Error example schema

### DIFF
--- a/workflows/schemas/workflow-output-schema.json
+++ b/workflows/schemas/workflow-output-schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "WorkflowResult",
+    "description": "Schema of workflow output",
+    "type": "object",
+    "properties": {
+        "result": {
+            "$ref": "workflow-result-schema.json",
+            "type": "object"
+        }
+    }
+}

--- a/workflows/schemas/workflow-result-schema.json
+++ b/workflows/schemas/workflow-result-schema.json
@@ -49,9 +49,13 @@
                     },
                     "value": {
                         "description": "Free form value of the option.",
-                        "type": [
-                            "string",
-                            "number"
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
                         ]
                     },
                     "format": {

--- a/workflows/schemas/workflow-result-schema.json
+++ b/workflows/schemas/workflow-result-schema.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "WorkflowResult",
+    "description": "Result of a workflow execution",
+    "type": "object",
+    "properties": {
+        "completedWith": {
+            "description": "The state of workflow completion.",
+            "type": "string",
+            "enum": [
+                "error",
+                "success"
+            ]
+        },
+        "message": {
+            "description": "High-level summary of the current status, free-form text, human readable.",
+            "type": "string"
+        },
+        "nextWorkflows": {
+            "description": "List of workflows suggested to run next. Items at lower indexes are of higher priority.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "Workflow identifier",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Human readable title describing the workflow.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            }
+        },
+        "outputs": {
+            "description": "Additional structured output of workflow processing. This can contain identifiers of created resources, links to resources, logs or other output.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "description": "Unique identifier of the option. Preferably human-readable.",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Free form value of the option.",
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    },
+                    "format": {
+                        "description": "More detailed type of the 'value' property. Defaults to 'text'.",
+                        "enum": [
+                            "text",
+                            "number",
+                            "link"
+                        ]
+                    }
+                },
+                "required": [
+                    "key",
+                    "value"
+                ]
+            }
+        }
+    }
+}

--- a/workflows/wait-or-error.sw.yaml
+++ b/workflows/wait-or-error.sw.yaml
@@ -13,18 +13,24 @@ functions:
   - name: logFunction
     type: custom
     operation: sysout
-  - name: throwError
-    operation: specs/actions-openapi.json#unknown-action
 states:
   - name: ChooseOnState
     type: switch
     dataConditions:
       - condition: ${ .state == "Wait" }
-        transition: WaitTimeout
+        transition: WaitFlow
       - condition: ${ .state == "Error" }
-        transition: ThrowError
+        transition: ErrorFlow
     defaultCondition:
       transition: WaitTimeout
+  - name: WaitFlow
+    type: inject
+    data:
+      result:
+        outputs:
+          - key: dataFeed
+            value: This string is produced while waiting
+    transition: WaitTimeout
   - name: WaitTimeout
     type: callback
     action:
@@ -35,12 +41,55 @@ states:
           message: Callback
     eventRef: callbackEvent
     timeouts:
-      eventTimeout: PT20S
+      eventTimeout: PT10S
+    transition: ProduceOutput
+  - name: ProduceOutput
+    type: inject
+    data:
+      result:
+        completedWith: success
+        message: A human-readable description of the error.
+        nextWorkflows:
+          - id: next-workflow-id
+            name: Suggested next workflow 
+          - id: second-next-workflow-id
+            name: Less important next workflow
+        outputs:
+          - key: resourceOne
+            value: FirstCreatedResourceName
+          - key: resourceTwo
+            value: SecondCreatedResourceName
+            format: text
+          - key: countOfSomething
+            value: 42
+            format: number
+          - key: Important link somewhere
+            value: https://foo.bar
+            format: link
+          - key: Important link somewhere else
+            value: https://foo.bar.com
+            format: link
+      foo: Whatever other data for backward compatibility
     end: true
-  - name: ThrowError
-    type: operation
-    actions:
-      - name: throwError
-        functionRef:
-          refName: throwError
+  - name: ErrorFlow
+    type: inject
+    data:
+      result:
+        completedWith: error
+        message: A human-readable description of the error. However, still some additional output could be produced till an error occurred.
+        outputs:
+          - key: resourceOne
+            value: FirstCreatedResourceName
+          - key: resourceTwo
+            value: SecondCreatedResourceName
+            format: text
+          - key: countOfSomething
+            value: 42
+            format: number
+          - key: Important link somewhere
+            value: https://foo.bar
+            format: link
+          - key: Important link somewhere else
+            value: https://foo.bar.com
+            format: link
     end: true

--- a/workflows/wait-or-error.sw.yaml
+++ b/workflows/wait-or-error.sw.yaml
@@ -3,8 +3,11 @@ version: "1.0"
 specVersion: "0.8"
 name: Wait or Error
 description: Simple workflow to simulate waiting for callback or error
-dataInputSchema: schemas/wait-or-error__main-schema.json
 start: ChooseOnState
+dataInputSchema: schemas/wait-or-error__main-schema.json
+extensions:
+  - extensionid: workflow-output-schema
+    outputSchema: schemas/workflow-result-schema.json
 events:
   - name: callbackEvent
     type: wait-or-error
@@ -26,10 +29,9 @@ states:
   - name: WaitFlow
     type: inject
     data:
-      result:
-        outputs:
-          - key: dataFeed
-            value: This string is produced while waiting
+      outputs:
+        - key: dataFeed
+          value: This string is produced while waiting and will be replaced by later output
     transition: WaitTimeout
   - name: WaitTimeout
     type: callback
@@ -46,50 +48,47 @@ states:
   - name: ProduceOutput
     type: inject
     data:
-      result:
-        completedWith: success
-        message: A human-readable description of the error.
-        nextWorkflows:
-          - id: next-workflow-id
-            name: Suggested next workflow 
-          - id: second-next-workflow-id
-            name: Less important next workflow
-        outputs:
-          - key: resourceOne
-            value: FirstCreatedResourceName
-          - key: resourceTwo
-            value: SecondCreatedResourceName
-            format: text
-          - key: countOfSomething
-            value: 42
-            format: number
-          - key: Important link somewhere
-            value: https://foo.bar
-            format: link
-          - key: Important link somewhere else
-            value: https://foo.bar.com
-            format: link
-      foo: Whatever other data for backward compatibility
+      completedWith: success
+      message: A human-readable description of the completion status.
+      nextWorkflows:
+        - id: next-workflow-id
+          name: Suggested next workflow
+        - id: second-next-workflow-id
+          name: Less important next workflow
+      outputs:
+        - key: resourceOne
+          value: FirstCreatedResourceName
+        - key: resourceTwo
+          value: SecondCreatedResourceName
+          format: text
+        - key: countOfSomething
+          value: 42
+          format: number
+        - key: Important link somewhere
+          value: https://foo.bar
+          format: link
+        - key: Important link somewhere else
+          value: https://foo.bar.com
+          format: link
     end: true
   - name: ErrorFlow
     type: inject
     data:
-      result:
-        completedWith: error
-        message: A human-readable description of the error. However, still some additional output could be produced till an error occurred.
-        outputs:
-          - key: resourceOne
-            value: FirstCreatedResourceName
-          - key: resourceTwo
-            value: SecondCreatedResourceName
-            format: text
-          - key: countOfSomething
-            value: 42
-            format: number
-          - key: Important link somewhere
-            value: https://foo.bar
-            format: link
-          - key: Important link somewhere else
-            value: https://foo.bar.com
-            format: link
+      completedWith: error
+      message: A human-readable description of the error. However, still some additional output could be produced till an error occurred.
+      outputs:
+        - key: resourceOne
+          value: FirstCreatedResourceName
+        - key: resourceTwo
+          value: SecondCreatedResourceName
+          format: text
+        - key: countOfSomething
+          value: 42
+          format: number
+        - key: Important link somewhere
+          value: https://foo.bar
+          format: link
+        - key: Important link somewhere else
+          value: https://foo.bar.com
+          format: link
     end: true

--- a/workflows/wait-or-error.sw.yaml
+++ b/workflows/wait-or-error.sw.yaml
@@ -7,7 +7,7 @@ start: ChooseOnState
 dataInputSchema: schemas/wait-or-error__main-schema.json
 extensions:
   - extensionid: workflow-output-schema
-    outputSchema: schemas/workflow-result-schema.json
+    outputSchema: schemas/workflow-output-schema.json
 events:
   - name: callbackEvent
     type: wait-or-error

--- a/workflows/wait-or-error.sw.yaml
+++ b/workflows/wait-or-error.sw.yaml
@@ -48,47 +48,49 @@ states:
   - name: ProduceOutput
     type: inject
     data:
-      completedWith: success
-      message: A human-readable description of the completion status.
-      nextWorkflows:
-        - id: next-workflow-id
-          name: Suggested next workflow
-        - id: second-next-workflow-id
-          name: Less important next workflow
-      outputs:
-        - key: resourceOne
-          value: FirstCreatedResourceName
-        - key: resourceTwo
-          value: SecondCreatedResourceName
-          format: text
-        - key: countOfSomething
-          value: 42
-          format: number
-        - key: Important link somewhere
-          value: https://foo.bar
-          format: link
-        - key: Important link somewhere else
-          value: https://foo.bar.com
-          format: link
+      result:
+        completedWith: success
+        message: A human-readable description of the completion status.
+        nextWorkflows:
+          - id: next-workflow-id
+            name: Suggested next workflow
+          - id: second-next-workflow-id
+            name: Less important next workflow
+        outputs:
+          - key: resourceOne
+            value: FirstCreatedResourceName
+          - key: resourceTwo
+            value: SecondCreatedResourceName
+            format: text
+          - key: countOfSomething
+            value: 42
+            format: number
+          - key: Important link somewhere
+            value: https://foo.bar
+            format: link
+          - key: Important link somewhere else
+            value: https://foo.bar.com
+            format: link
     end: true
   - name: ErrorFlow
     type: inject
     data:
-      completedWith: error
-      message: A human-readable description of the error. However, still some additional output could be produced till an error occurred.
-      outputs:
-        - key: resourceOne
-          value: FirstCreatedResourceName
-        - key: resourceTwo
-          value: SecondCreatedResourceName
-          format: text
-        - key: countOfSomething
-          value: 42
-          format: number
-        - key: Important link somewhere
-          value: https://foo.bar
-          format: link
-        - key: Important link somewhere else
-          value: https://foo.bar.com
-          format: link
+      result:
+        completedWith: error
+        message: A human-readable description of the error. However, still some additional output could be produced till an error occurred.
+        outputs:
+          - key: resourceOne
+            value: FirstCreatedResourceName
+          - key: resourceTwo
+            value: SecondCreatedResourceName
+            format: text
+          - key: countOfSomething
+            value: 42
+            format: number
+          - key: Important link somewhere
+            value: https://foo.bar
+            format: link
+          - key: Important link somewhere else
+            value: https://foo.bar.com
+            format: link
     end: true


### PR DESCRIPTION
Adding new WorkflowResult ([PR 403](https://github.com/parodos-dev/serverless-workflows/pull/403)) into an example `wait-or-error` workflow.